### PR TITLE
Fix typo causing NullPointerException

### DIFF
--- a/osm-tools-pbf/src/main/java/crosby/binary/OsmInfoReader.java
+++ b/osm-tools-pbf/src/main/java/crosby/binary/OsmInfoReader.java
@@ -25,7 +25,7 @@ public class OsmInfoReader {
 	}
 
 	public boolean hasValidUserId() {
-		return (info != null & info.hasUid() && info.hasUserSid() && info.getUid() >= 0);
+		return (info != null && info.hasUid() && info.hasUserSid() && info.getUid() >= 0);
 	}
 
 	public int getUserSid() {


### PR DESCRIPTION
Fixes a NPE I was seeing with the following stack:
Exception in thread "main" java.lang.NullPointerException
    at crosby.binary.OsmInfoReader.hasValidUserId(OsmInfoReader.java:28)
    at crosby.binary.OsmObjectFactory.createOsmInfo(OsmObjectFactory.java:62)
    at crosby.binary.OsmObjectFactory.createWay(OsmObjectFactory.java:145)
    at org.osmtools.pbf.OsmPbfParser.parseWays(OsmPbfParser.java:34)
    at crosby.binary.BinaryParser.parse(BinaryParser.java:67)
        ...
